### PR TITLE
Disable hardware acceleration for large bitmaps

### DIFF
--- a/cropper/src/main/java/net/realify/lib/androidimagecropper/CropImageView.java
+++ b/cropper/src/main/java/net/realify/lib/androidimagecropper/CropImageView.java
@@ -1195,6 +1195,11 @@ public class CropImageView extends FrameLayout {
       clearImageInt();
 
       mBitmap = bitmap;
+
+      if (mBitmap.getByteCount() > 200000000) {
+        mImageView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+      }
+      
       mImageView.setImageBitmap(mBitmap);
 
       mLoadedImageUri = imageUri;


### PR DESCRIPTION
Turning off hardware acceleration for the ImageView allows displaying larger bitmaps.

The app crashes on my phone with large images:
```
FATAL EXCEPTION: main
Process: de.k3b.android.lossless_jpg_crop.debug, PID: 15142
java.lang.RuntimeException: Canvas: trying to draw too large(209960016bytes) bitmap.
```

I assume this is a device specific limit, ~200 MB seems to be the limit on my phone. 
Presumably there is also a limit when hardware acceleration is off. 
My camera takes 200 megapixel images, which is about ~800 MB as a bitmap and those display fine this way.
